### PR TITLE
fix: add cargo-mero to formula generation

### DIFF
--- a/.github/workflows/test-brew-install.yaml
+++ b/.github/workflows/test-brew-install.yaml
@@ -34,6 +34,7 @@ jobs:
         run: |
           brew install meroctl
           brew install merod
+          brew install cargo-mero
 
       - name: Validate binaries installation
         run: |
@@ -41,3 +42,5 @@ jobs:
           meroctl --version
           which merod
           merod --version
+          which cargo-mero
+          cargo-mero mero --version

--- a/Formula/cargo-mero.rb
+++ b/Formula/cargo-mero.rb
@@ -1,0 +1,28 @@
+class CargoMero < Formula
+  desc "Calimero application toolchain: scaffold, build, test, and bundle WASM apps"
+  homepage "https://github.com/calimero-network/core"
+  version "0.11.0-rc.19"
+
+  if OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/cargo-mero_aarch64-apple-darwin.tar.gz"
+    sha256 "096f49b3aa4f6bbf56e55972a25dec711c5b726009730f4b34c51afa1f1ecbb3"
+  elsif OS.mac? && Hardware::CPU.intel?
+    odie "Intel macOS binaries are not available for 0.11.0-rc.19"
+  elsif OS.linux? && Hardware::CPU.arm?
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/cargo-mero_aarch64-unknown-linux-gnu.tar.gz"
+    sha256 "ff37e6266aeda16d7bc5748bf6d0f7b5aebf4fcdea31e1b1c9acad013b987e95"
+  elsif OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/cargo-mero_x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "b2b758deb7eaf30ccd956292be8f476277c733335c8a9c9738256ab219d5daca"
+  else
+    odie "Unsupported platform"
+  end
+
+  def install
+    bin.install "cargo-mero"
+  end
+
+  test do
+    assert_match "CargoMero CLI", shell_output("#{bin}/cargo-mero --help")
+  end
+end

--- a/Formula/mero-abi.rb
+++ b/Formula/mero-abi.rb
@@ -1,19 +1,19 @@
 class MeroAbi < Formula
   desc "CLI tool for extracting Calimero WASM ABI"
   homepage "https://github.com/calimero-network/core"
-  version "0.11.0-rc.18"
+  version "0.11.0-rc.19"
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/mero-abi_aarch64-apple-darwin.tar.gz"
-    sha256 "c6b4e0262891b84ea4a10f6ef75d1e7f782f5ecd7c3c271416898b2bb41ba771"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/mero-abi_aarch64-apple-darwin.tar.gz"
+    sha256 "bf474736a68766cdc950ee51c79c3a83cdc36114554f4778dc5a789a43ea7c1d"
   elsif OS.mac? && Hardware::CPU.intel?
-    odie "Intel macOS binaries are not available for 0.11.0-rc.18"
+    odie "Intel macOS binaries are not available for 0.11.0-rc.19"
   elsif OS.linux? && Hardware::CPU.arm?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/mero-abi_aarch64-unknown-linux-gnu.tar.gz"
-    sha256 "dfe4019b3bd2376baf7ab21c790595d58a16462657afdf91eb6accb523f15e79"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/mero-abi_aarch64-unknown-linux-gnu.tar.gz"
+    sha256 "63bb1f4e812f587c2d8b13f966052d9b13afeab6c24518d5db64b2b8b5bc0196"
   elsif OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/mero-abi_x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "c42c785f7826a907f1985aa0da9d69eb9201849cd437654ded1bffc5c4499009"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/mero-abi_x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "f835ae25d4adc123c8b87ea02274a470080dadbaf65f6ee40dd212ac02dd4b39"
   else
     odie "Unsupported platform"
   end

--- a/Formula/meroctl.rb
+++ b/Formula/meroctl.rb
@@ -1,19 +1,19 @@
 class Meroctl < Formula
   desc "Command-line tool for Calimero Network"
   homepage "https://github.com/calimero-network/core"
-  version "0.11.0-rc.18"
+  version "0.11.0-rc.19"
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/meroctl_aarch64-apple-darwin.tar.gz"
-    sha256 "30dff4ae87d28c6a47b1a3ec36695d30a7b66a3e3697fc079c4030d9c824a2c7"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/meroctl_aarch64-apple-darwin.tar.gz"
+    sha256 "8760881b0bbdf1a5a17293c7899b710476eb28988adb1b112e70539c59cdb4c1"
   elsif OS.mac? && Hardware::CPU.intel?
-    odie "Intel macOS binaries are not available for 0.11.0-rc.18"
+    odie "Intel macOS binaries are not available for 0.11.0-rc.19"
   elsif OS.linux? && Hardware::CPU.arm?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/meroctl_aarch64-unknown-linux-gnu.tar.gz"
-    sha256 "1b284caa34f00a250adb2bc3ff9d10bf4e08f83bae1a8374d5345adbbd892459"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/meroctl_aarch64-unknown-linux-gnu.tar.gz"
+    sha256 "fd719105d360b5de24dc7df9e534902e4636ccc277b0128028d20f1120f26875"
   elsif OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/meroctl_x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "16a3df79d1d75218b7c17e3c3913750a3053f687899c78f5dd71524911a0bd31"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/meroctl_x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "980b2520f6176460adc91ee80111f367f1b82ff2a44fbffac80be103e3ba9f23"
   else
     odie "Unsupported platform"
   end

--- a/Formula/merod.rb
+++ b/Formula/merod.rb
@@ -1,19 +1,19 @@
 class Merod < Formula
   desc "Command-line tool for Calimero Network setup"
   homepage "https://github.com/calimero-network/core"
-  version "0.11.0-rc.18"
+  version "0.11.0-rc.19"
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/merod_aarch64-apple-darwin.tar.gz"
-    sha256 "4cb6ac9582d5aefb5afbff58f8fd95d1d0295ad1a36203de67620b14d963d2d2"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/merod_aarch64-apple-darwin.tar.gz"
+    sha256 "3580abdba8a7a1bfa3260ecb234227cc6d482d2ae17cfeb4702e330b23dcda50"
   elsif OS.mac? && Hardware::CPU.intel?
-    odie "Intel macOS binaries are not available for 0.11.0-rc.18"
+    odie "Intel macOS binaries are not available for 0.11.0-rc.19"
   elsif OS.linux? && Hardware::CPU.arm?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/merod_aarch64-unknown-linux-gnu.tar.gz"
-    sha256 "2137d1f7305923160f2d102cee16fd175753d6b5b7b0fdfb741f75415171c02a"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/merod_aarch64-unknown-linux-gnu.tar.gz"
+    sha256 "98318fb0f092804cb32ffaade2eadfba471ce47f9c44570dee2e07f9a68c3059"
   elsif OS.linux? && Hardware::CPU.intel?
-    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.18/merod_x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "d93f376b2b47cc7db48d8eeca37e7bc83a395f05dad52428e113593b2cdfe866"
+    url "https://github.com/calimero-network/core/releases/download/0.11.0-rc.19/merod_x86_64-unknown-linux-gnu.tar.gz"
+    sha256 "546df015092aede7f6edb2856d26716ffc6c20af2bd1b35fdac20e4c8385c1c7"
   else
     odie "Unsupported platform"
   end

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -34,6 +34,7 @@ DESCRIPTIONS=(
   ["meroctl"]="Command-line tool for Calimero Network"
   ["mero-abi"]="CLI tool for extracting Calimero WASM ABI"
   ["mero-relayer"]="Service for relaying requests from Calimero to external blockchains"
+  ["cargo-mero"]="Calimero application toolchain: scaffold, build, test, and bundle WASM apps"
 )
 
 if [ -z "${DESCRIPTIONS[$BINARY]-}" ]; then
@@ -48,6 +49,7 @@ PRETTY_NAMES=(
   ["meroctl"]="Meroctl"
   ["mero-abi"]="MeroAbi"
   ["mero-relayer"]="MeroRelayer"
+  ["cargo-mero"]="CargoMero"
 )
 
 if [ -z "${PRETTY_NAMES[$BINARY]-}" ]; then


### PR DESCRIPTION
## Summary

The `Update Homebrew Tap` job of core's Release workflow has been failing since `cargo-mero` was added to `HOMEBREW_BINARIES` ([run 30544428075](https://github.com/calimero-network/core/actions/runs/30544428075/job/90961071973)):

```
Updating formula for cargo-mero, version: 0.11.0-rc.19
Unsupported binary: cargo-mero
##[error]Process completed with exit code 1.
```

`generate-formula.sh` gates on hardcoded `DESCRIPTIONS` / `PRETTY_NAMES` maps that only list `merod`, `meroctl`, `mero-abi` and `mero-relayer`. The script exits before `git add`/`commit`/`push`, so nothing was published at all: `merod`, `meroctl` and `mero-abi` were also left at `0.11.0-rc.18`.

Changes:

- Add `cargo-mero` to both maps. That is the whole fix, two lines.
- Add the generated `Formula/cargo-mero.rb` at `0.11.0-rc.19`, so `brew install cargo-mero` works now rather than after the next release.
- Bump `merod`, `meroctl` and `mero-abi` to `0.11.0-rc.19`, which is what the failed job would have committed.
- Install and validate `cargo-mero` in `test-brew-install.yaml`, so a formula that does not generate or does not run is caught here instead of in core's release job. The step uses `cargo-mero mero --version`: cargo plugins take the subcommand as `argv[1]`, so a bare `cargo-mero --version` exits 2.

## Test plan

Run against the real published `0.11.0-rc.19` artifacts, with bash 5 (the script needs associative arrays, so macOS `/bin/bash` 3.2 cannot run it):

```
for b in merod meroctl mero-abi cargo-mero; do ./generate-formula.sh "$b" "0.11.0-rc.19"; done
```

All four now generate, with real SHA256 digests. Before this change the first three succeeded and `cargo-mero` exited 1.

Formula verified end to end by linking this branch as a local tap:

| check | result |
| --- | --- |
| `brew audit --formula cargo-mero` | exit 0 |
| `brew install cargo-mero` | exit 0 |
| `cargo-mero mero --version` (the new CI step) | exit 0 |
| `cargo mero guide` | prints the workflow guide |

The new CI step was checked as a real gate, not just observed passing: with `Formula/cargo-mero.rb` moved aside `brew install cargo-mero` exits 1, and with it in place exits 0.

## Pre-existing issues found, deliberately not fixed here

**The `test do` assertion has never worked, for any formula.** Every generated formula asserts `"<PrettyName> CLI"` appears in `<binary> --help`, and no binary prints that:

```
merod --help   contains 'Merod CLI':   0 matches   (prints "Usage: merod [OPTIONS] --node <NAME> <COMMAND>")
meroctl --help contains 'Meroctl CLI': 0 matches   (prints "Usage: meroctl [OPTIONS] <COMMAND>")
```

Nothing has noticed because `test-brew-install.yaml` runs `brew install` plus `--version`, never `brew test`. `cargo-mero` inherits the same broken assertion, consistently with the rest. Fixing it means deciding what these tests should assert across all five formulas, which is its own change and does not belong in a release unblock.

**Version mismatch.** `cargo-mero` self-reports `0.1.0` (its own `tools/cargo-mero/Cargo.toml` version) while the release tag and this formula say `0.11.0-rc.19`. That lives in core, not in the tap.